### PR TITLE
Simplify + clarify usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,7 @@ project(code_coverage)
 
 find_package(catkin REQUIRED)
 
-option(ENABLE_COVERAGE_TESTING "Turn on coverage testing" OFF)
 catkin_package(CFG_EXTRAS code_coverage-extras.cmake)
-
-if (ENABLE_COVERAGE_TESTING)
-  message(STATUS "Using ENABLE_COVERAGE_TESTING: ${ENABLE_COVERAGE_TESTING}")
-endif()
 
 ## Install all cmake files
 install(DIRECTORY cmake/Modules

--- a/README.md
+++ b/README.md
@@ -8,20 +8,22 @@ To use this with your ROS package:
  * Add code_coverage as a test depend in your package.xml
  * Update your CMakeLists.txt, in the testing section add:
 ```
-if (CATKIN_ENABLE_TESTING)
+if(CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)
   find_package(code_coverage REQUIRED)
+  # Add compiler flags for coverage instrumentation before defining any targets
+  APPEND_COVERAGE_COMPILER_FLAGS()
+endif()
 
-  if(ENABLE_COVERAGE_TESTING)
-    include(CodeCoverage)
-    APPEND_COVERAGE_COMPILER_FLAGS()
-  endif()
+# Add your targets here
 
+if (CATKIN_ENABLE_TESTING)
   # Add your tests here
 
+  # Create a target ${PROJECT_NAME}_coverage_report
   if(ENABLE_COVERAGE_TESTING)
     set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*" "*/${PROJECT_NAME}/other_dir_i_dont_care_about*")
     add_code_coverage(
-      NAME ${PROJECT_NAME}_coverage
+      NAME ${PROJECT_NAME}_coverage_report
       DEPENDENCIES tests
     )
   endif()

--- a/cmake/Modules/CodeCoverage.cmake
+++ b/cmake/Modules/CodeCoverage.cmake
@@ -171,3 +171,5 @@ function(APPEND_COVERAGE_COMPILER_FLAGS)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
     message(STATUS "Appending code coverage compiler flags: ${COVERAGE_COMPILER_FLAGS}")
 endfunction() # APPEND_COVERAGE_COMPILER_FLAGS
+
+option(ENABLE_COVERAGE_TESTING "Turn on coverage testing" OFF)

--- a/cmake/Modules/CodeCoverage.cmake
+++ b/cmake/Modules/CodeCoverage.cmake
@@ -1,5 +1,6 @@
 # Copyright (c) 2012 - 2017, Lars Bilke
 # All rights reserved.
+# From: https://github.com/bilke/cmake-modules/blob/master/CodeCoverage.cmake
 #
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:

--- a/cmake/code_coverage-extras.cmake.develspace.in
+++ b/cmake/code_coverage-extras.cmake.develspace.in
@@ -1,2 +1,3 @@
 # Append cmake modules from source directory to the cmake module path
 list(APPEND CMAKE_MODULE_PATH "@CMAKE_CURRENT_SOURCE_DIR@/cmake/Modules")
+include(CodeCoverage)

--- a/cmake/code_coverage-extras.cmake.installspace.in
+++ b/cmake/code_coverage-extras.cmake.installspace.in
@@ -1,2 +1,3 @@
 # Append the installed cmake modules to the cmake module path
 list(APPEND CMAKE_MODULE_PATH "${code_coverage_DIR}/../../../@CATKIN_PACKAGE_SHARE_DESTINATION@/cmake/Modules")
+include(CodeCoverage)


### PR DESCRIPTION
As we are planning to use this package for MoveIt's Travis checks (https://github.com/ros-planning/moveit_ci/pull/91), I would like to incorporate some simplifications, fixes, and clarifications before:
- `include(CodeCoverage)` shouldn't be required explicitly. Rather these definitions should be included via `find_package()` already.
- Defining the option `ENABLE_COVERAGE_TESTING` in the package's cmake file doesn't make sense. It needs to be defined in the module included by downstream packages.
- The README should clarify that this package provides two things:
  - It allows the instrumentation of the generated code for coverage reporting - via `APPEND_COVERAGE_COMPILER_FLAGS()`
  - It allows to generate the html coverage report - via `add_code_coverage()`

@mikeferguson, would be great, if you could create a new release into Kinetic and Melodic if this has been merged.