### PR TITLE
Do not depend on building all tests in the workspace

### DIFF
--- a/cmake/Modules/CodeCoverage.cmake
+++ b/cmake/Modules/CodeCoverage.cmake
@@ -149,7 +149,7 @@ function(ADD_CODE_COVERAGE)
 
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
         DEPENDS ${Coverage_NAME}_cleanup
-        DEPENDS _run_tests_${PROJECT_NAME}
+        DEPENDS run_tests_${PROJECT_NAME}
         COMMENT "Processing code coverage counters and generating report."
     )
 


### PR DESCRIPTION
The hidden target `_run_tests_${PROJECT_NAME}` depends on the `tests` target, which builds all tests in the workspace. In contrast, with `run_tests_${PROJECT_NAME}` only the tests of `${PROJECT_NAME}` are built.