### PR TITLE
Add catkin_make build step in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ endif()
 
   - if using CATKIN_MAKE:
   ```
+      catkin_make -DENABLE_COVERAGE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug
       catkin_make -DENABLE_COVERAGE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug PACKAGE_NAME_coverage_report
   ```
   - if using CATKIN_TOOLS:


### PR DESCRIPTION
If you omit this step, the coverage baseline might be created too early and you get an unreliable coverage report.