### PR TITLE
[fix] lcov file not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,28 +11,28 @@ To use this with your ROS package:
 
  * Add code_coverage as a test depend in your package.xml
  * Update your CMakeLists.txt, in the testing section add:
-```
-if(CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)
-  find_package(code_coverage REQUIRED)
-  # Add compiler flags for coverage instrumentation before defining any targets
-  APPEND_COVERAGE_COMPILER_FLAGS()
-endif()
-
-# Add your targets here
-
-if (CATKIN_ENABLE_TESTING)
-  # Add your tests here
-
-  # Create a target ${PROJECT_NAME}_coverage_report
-  if(ENABLE_COVERAGE_TESTING)
-    set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*" "*/${PROJECT_NAME}/other_dir_i_dont_care_about*")
-    add_code_coverage(
-      NAME ${PROJECT_NAME}_coverage_report
-      DEPENDENCIES tests
-    )
-  endif()
-endif()
-```
+   ```
+   if(CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)
+     find_package(code_coverage REQUIRED)
+     # Add compiler flags for coverage instrumentation before defining any targets
+     APPEND_COVERAGE_COMPILER_FLAGS()
+   endif()
+   
+   # Add your targets here
+   
+   if (CATKIN_ENABLE_TESTING)
+     # Add your tests here
+   
+     # Create a target ${PROJECT_NAME}_coverage_report
+     if(ENABLE_COVERAGE_TESTING)
+       set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*" "*/${PROJECT_NAME}/other_dir_i_dont_care_about*")
+       add_code_coverage(
+         NAME ${PROJECT_NAME}_coverage_report
+         DEPENDENCIES tests
+       )
+     endif()
+   endif()
+   ```
 
 * Now you can build and run the tests (you need a debug build to get reasonable coverage numbers):
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ROS package to run coverage testing
 To use this with your ROS package:
 
  * Add code_coverage as a test depend in your package.xml
- * Update your CMakeLists.txt, in the testing section add:
+ * Update your CMakeLists.txt, in the testing section add the following. **NOTE** the order of test targets and coverage macros:
    ```
    if(CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)
      find_package(code_coverage REQUIRED)

--- a/cmake/Modules/CodeCoverage.cmake
+++ b/cmake/Modules/CodeCoverage.cmake
@@ -168,6 +168,7 @@ function(ADD_CODE_COVERAGE)
 
     # Create C++ coverage report
     add_custom_target(${Coverage_NAME}_cpp
+        COMMAND export PYTHONIOENCODING=UTF-8
         # Capturing lcov counters and generating report
         COMMAND ${LCOV_PATH} --directory . --capture --output-file ${Coverage_NAME}.info
         # add baseline counters

--- a/cmake/Modules/CodeCoverage.cmake
+++ b/cmake/Modules/CodeCoverage.cmake
@@ -149,7 +149,7 @@ function(ADD_CODE_COVERAGE)
         # Cleanup lcov
         COMMAND ${LCOV_PATH} --directory . --zerocounters
         # Create baseline to make sure untouched files show up in the report
-        COMMAND ${LCOV_PATH} -c -i -d . -o ${Coverage_NAME}.base
+        COMMAND ${LCOV_PATH} -c -i -d . -o ${PROJECT_BINARY_DIR}/${Coverage_NAME}.base
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
         DEPENDS ${Coverage_DEPENDENCIES}
         COMMENT "Resetting CPP code coverage counters to zero."
@@ -170,13 +170,13 @@ function(ADD_CODE_COVERAGE)
     add_custom_target(${Coverage_NAME}_cpp
         COMMAND export PYTHONIOENCODING=UTF-8
         # Capturing lcov counters and generating report
-        COMMAND ${LCOV_PATH} --directory . --capture --output-file ${Coverage_NAME}.info
+        COMMAND ${LCOV_PATH} --directory . --capture --output-file ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info
         # add baseline counters
-        COMMAND ${LCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.info --output-file ${PROJECT_BINARY_DIR}/${Coverage_NAME}.total || (exit 0)
+        COMMAND ${LCOV_PATH} -a ${PROJECT_BINARY_DIR}/${Coverage_NAME}.base -a ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info --output-file ${PROJECT_BINARY_DIR}/${Coverage_NAME}.total || (exit 0)
         COMMAND ${LCOV_PATH} --remove ${PROJECT_BINARY_DIR}/${Coverage_NAME}.total ${COVERAGE_EXCLUDES} --output-file ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.removed || (exit 0)
         COMMAND ${LCOV_PATH} --extract ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.removed "'*/${PROJECT_NAME}/*'" --output-file ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned || (exit 0)
         COMMAND ${GENHTML_PATH} ${GENHTML_EXTRA_FLAGS} -o ${Coverage_NAME} ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned || (exit 0)
-        COMMAND ${CMAKE_COMMAND} -E remove ${Coverage_NAME}.base ${Coverage_NAME}.total || (exit 0)
+        COMMAND ${CMAKE_COMMAND} -E remove ${PROJECT_BINARY_DIR}/${Coverage_NAME}.base ${PROJECT_BINARY_DIR}/${Coverage_NAME}.total || (exit 0)
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
         DEPENDS _run_tests_${PROJECT_NAME}
     )

--- a/cmake/Modules/CodeCoverage.cmake
+++ b/cmake/Modules/CodeCoverage.cmake
@@ -171,8 +171,8 @@ function(ADD_CODE_COVERAGE)
         # Capturing lcov counters and generating report
         COMMAND ${LCOV_PATH} --directory . --capture --output-file ${Coverage_NAME}.info
         # add baseline counters
-        COMMAND ${LCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.info --output-file ${Coverage_NAME}.total || (exit 0)
-        COMMAND ${LCOV_PATH} --remove ${Coverage_NAME}.total ${COVERAGE_EXCLUDES} --output-file ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.removed || (exit 0)
+        COMMAND ${LCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.info --output-file ${PROJECT_BINARY_DIR}/${Coverage_NAME}.total || (exit 0)
+        COMMAND ${LCOV_PATH} --remove ${PROJECT_BINARY_DIR}/${Coverage_NAME}.total ${COVERAGE_EXCLUDES} --output-file ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.removed || (exit 0)
         COMMAND ${LCOV_PATH} --extract ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.removed "'*/${PROJECT_NAME}/*'" --output-file ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned || (exit 0)
         COMMAND ${GENHTML_PATH} ${GENHTML_EXTRA_FLAGS} -o ${Coverage_NAME} ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned || (exit 0)
         COMMAND ${CMAKE_COMMAND} -E remove ${Coverage_NAME}.base ${Coverage_NAME}.total || (exit 0)


### PR DESCRIPTION
This PR is work of @KrishnaBhatu.

# Problem
code_coverage run fails. We noticed soon after the following is printed.
```
lcov: ERROR: cannot read file pkg_furrr_coverage.total!
```

<details><summary>More log</summary>

```
rostest log file is in /root/.ros/log/rostest-b5602a7d7fa1-9160.log
-- run_tests.py: verify result "/catkin_ws/build/pkg_furrr/test_results/pkg_furrr/rostest-test_calibration_util.xml"
make[3]: Leaving directory '/catkin_ws/build/pkg_furrr'
[ 96%] Built target _run_tests_pkg_furrr_rostest_test_calibration_util.test
/usr/bin/make -f CMakeFiles/_run_tests_pkg_furrr_rostest.dir/build.make CMakeFiles/_run_tests_pkg_furrr_rostest.dir/depend
make[3]: Entering directory '/catkin_ws/build/pkg_furrr'
cd /catkin_ws/build/pkg_furrr && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /catkin_ws/src/pkg_mooo/pkg_furrr /catkin_ws/src/pkg_mooo/pkg_furrr /catkin_ws/build/pkg_furrr /catkin_ws/build/pkg_furrr /catkin_ws/build/pkg_furrr/CMakeFiles/_run_tests_pkg_furrr_rostest.dir/DependInfo.cmake --color=
make[3]: Leaving directory '/catkin_ws/build/pkg_furrr'
/usr/bin/make -f CMakeFiles/_run_tests_pkg_furrr_rostest.dir/build.make CMakeFiles/_run_tests_pkg_furrr_rostest.dir/build
make[3]: Entering directory '/catkin_ws/build/pkg_furrr'
make[3]: Nothing to be done for 'CMakeFiles/_run_tests_pkg_furrr_rostest.dir/build'.
make[3]: Leaving directory '/catkin_ws/build/pkg_furrr'
[ 96%] Built target _run_tests_pkg_furrr_rostest
/usr/bin/make -f CMakeFiles/_run_tests_pkg_furrr.dir/build.make CMakeFiles/_run_tests_pkg_furrr.dir/depend
make[3]: Entering directory '/catkin_ws/build/pkg_furrr'
cd /catkin_ws/build/pkg_furrr && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /catkin_ws/src/pkg_mooo/pkg_furrr /catkin_ws/src/pkg_mooo/pkg_furrr /catkin_ws/build/pkg_furrr /catkin_ws/build/pkg_furrr /catkin_ws/build/pkg_furrr/CMakeFiles/_run_tests_pkg_furrr.dir/DependInfo.cmake --color=
make[3]: Leaving directory '/catkin_ws/build/pkg_furrr'
/usr/bin/make -f CMakeFiles/_run_tests_pkg_furrr.dir/build.make CMakeFiles/_run_tests_pkg_furrr.dir/build
make[3]: Entering directory '/catkin_ws/build/pkg_furrr'
make[3]: Nothing to be done for 'CMakeFiles/_run_tests_pkg_furrr.dir/build'.
make[3]: Leaving directory '/catkin_ws/build/pkg_furrr'
[ 96%] Built target _run_tests_pkg_furrr
Processing pkg_furrr.dir/src/observation_data_point.cpp.gcno
Processing pkg_furrr.dir/src/depth_camera_calibrator.cpp.gcno
Processing pkg_furrr.dir/src/visualization_util.cpp.gcno
Processing pkg_furrr.dir/src/caljob_yaml_parser.cpp.gcno
Processing pkg_furrr.dir/src/target.cpp.gcno
Processing target_util_tests.dir/test/target_util_tests.cpp.gcno
Finished .info-file creation
make[3]: Leaving directory '/catkin_ws/build/pkg_furrr'
[ 96%] Built target pkg_furrr_coverage_cleanup
/usr/bin/make -f CMakeFiles/pkg_furrr_coverage.dir/build.make CMakeFiles/pkg_furrr_coverage.dir/depend
make[3]: Entering directory '/catkin_ws/build/pkg_furrr'
cd /catkin_ws/build/pkg_furrr && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /catkin_ws/src/pkg_mooo/pkg_furrr /catkin_ws/src/pkg_mooo/pkg_furrr /catkin_ws/build/pkg_furrr /catkin_ws/build/pkg_furrr /catkin_ws/build/pkg_furrr/CMakeFiles/pkg_furrr_coverage.dir/DependInfo.cmake --color=
Dependee "/catkin_ws/build/pkg_furrr/CMakeFiles/pkg_furrr_coverage.dir/DependInfo.cmake" is newer than depender "/catkin_ws/build/pkg_furrr/CMakeFiles/pkg_furrr_coverage.dir/depend.internal".
Dependee "/catkin_ws/build/pkg_furrr/CMakeFiles/CMakeDirectoryInformation.cmake" is newer than depender "/catkin_ws/build/pkg_furrr/CMakeFiles/pkg_furrr_coverage.dir/depend.internal".
Scanning dependencies of target pkg_furrr_coverage
make[3]: Leaving directory '/catkin_ws/build/pkg_furrr'
/usr/bin/make -f CMakeFiles/pkg_furrr_coverage.dir/build.make CMakeFiles/pkg_furrr_coverage.dir/build
make[3]: Entering directory '/catkin_ws/build/pkg_furrr'
[100%] Processing code coverage counters and generating report.
/usr/bin/lcov --directory . --capture --output-file pkg_furrr_coverage.info
Capturing coverage data from .
Found gcov version: 5.4.0
Scanning . for .gcda files ...
Found 23 data files in .
Processing plane_util_tests.dir/test/plane_util_tests.cpp.gcda
Processing calibration_util_tests.dir/test/calibration_util_tests.cpp.gcda
Processing pkg_furrr.dir/src/visualization_util.cpp.gcda
Processing pkg_furrr.dir/src/observation_scenWARNING: Could not encode unicode characters. Please set the PYTHONIOENCODING environment variable to see complete output. (i.e. PYTHONIOENCODING=UTF-8)
...............................................................................
Failed     << pkg_furrr:make           [ Exited with code 2 ]
e.cpp.gcda
Processing pkg_furrr.dir/src/observation_data_point.cpp.gcda
Processing pkg_furrr.dir/src/camera_definition.cpp.gcda
Processing pkg_furrr.dir/src/ros_camera_observer.cpp.gcda
Processing pkg_furrr.dir/src/ros_transform_interface.cpp.gcda
Processing pkg_furrr.dir/src/basic_types.cpp.gcda
Processing pkg_furrr.dir/src/calibration_util.cpp.gcda
Processing pkg_furrr.dir/src/targets_yaml_parser.cpp.gcda
Processing pkg_furrr.dir/src/camera_yaml_parser.cpp.gcda
Processing pkg_furrr.dir/src/plane_util.cpp.gcda
Processing pkg_furrr.dir/src/caljob_yaml_parser.cpp.gcda
Processing pkg_furrr.dir/src/ceres_blocks.cpp.gcda
Processing pkg_furrr.dir/src/target_util.cpp.gcda
Processing pkg_furrr.dir/src/calibration_job_definition.cpp.gcda
Processing pkg_furrr.dir/src/target.cpp.gcda
Processing pkg_furrr.dir/src/ceres_costs_utils.cpp.gcda
Processing pkg_furrr.dir/src/depth_camera_calibrator.cpp.gcda
Processing pkg_furrr.dir/src/points_yaml_parser.cpp.gcda
Processing pkg_furrr.dir/src/circle_detector.cpp.gcda
Processing target_util_tests.dir/test/target_util_tests.cpp.gcda
Finished .info-file creation
/usr/bin/lcov -a pkg_furrr_coverage.base -a pkg_furrr_coverage.info --output-file pkg_furrr_coverage.total
Combining tracefiles.
Reading tracefile pkg_furrr_coverage.base
Reading tracefile pkg_furrr_coverage.info
lcov: WARNING: negative counts found in tracefile pkg_furrr_coverage.info
Writing data to pkg_furrr_coverage.total
Summary coverage rate:
  lines......: 15.2% (1939 of 12729 lines)
  functions..: 5.5% (433 of 7927 functions)
  branches...: no data found
/usr/bin/lcov --remove pkg_furrr_coverage.total --output-file /catkin_ws/build/pkg_furrr/pkg_furrr_coverage.info.removed
Reading tracefile pkg_furrr_coverage.total
lcov: ERROR: cannot read file pkg_furrr_coverage.total!
CMakeFiles/pkg_furrr_coverage.dir/build.make:57: recipe for target 'CMakeFiles/pkg_furrr_coverage' failed
make[3]: Leaving directory '/catkin_ws/build/pkg_furrr'
make[3]: *** [CMakeFiles/pkg_furrr_coverage] Error 2
CMakeFiles/Makefile2:1263: recipe for target 'CMakeFiles/pkg_furrr_coverage.dir/all' failed
make[2]: Leaving directory '/catkin_ws/build/pkg_furrr'
make[2]: *** [CMakeFiles/pkg_furrr_coverage.dir/all] Error 2
CMakeFiles/Makefile2:1270: recipe for target 'CMakeFiles/pkg_furrr_coverage.dir/rule' failed
make[1]: Leaving directory '/catkin_ws/build/pkg_furrr'
make[1]: *** [CMakeFiles/pkg_furrr_coverage.dir/rule] Error 2
make: *** [pkg_furrr_coverage] Error 2
Makefile:537: recipe for target 'pkg_furrr_coverage' failed
cd /catkin_ws/build/pkg_furrr; catkin build --get-env pkg_furrr | catkin env -si  /usr/bin/make run_tests pkg_furrr_coverage --jobserver-fds=6,7 -j; cd -
Failed    <<< pkg_furrr                [ 1 minute and 39.4 seconds ]
[build] Summary: 0 of 1 packages succeeded.
[build]   Ignored:   4 packages were skipped or are blacklisted.
[build]   Warnings:  1 packages succeeded with warnings.
[build]   Abandoned: None.
[build]   Failed:    1 packages failed.
[build] Runtime: 1 minute and 39.5 seconds total.
```
</details>

# Approach
We are not super sure, but explicitly passing the absolute path of the target file seems to fix.

# Some CoS
- [x] Issue fixes with `catkin_tools`.
- [x] Issue fixes with `catkin_make`.
