### PR TITLE
Add Clang coverage tools support (#30)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package code_coverage
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.4.5 (2021-09-29)
+------------------
+* Added option to use Clang coverage tools. (`#30 <https://github.com/mikeferguson/code_coverage/issues/30>`_)
+* Contributors: Erki Suurjaak
+
 0.4.4 (2020-10-29)
 ------------------
 * Added python3-coverage support and error if python*-coverage is missing. (`#27 <https://github.com/mikeferguson/code_coverage/issues/27>`_)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ find_package(catkin REQUIRED)
 
 catkin_package(CFG_EXTRAS code_coverage-extras.cmake)
 
+## Install Clang coverage tool wrapper
+install(PROGRAMS scripts/llvm-gcov.sh
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}/scripts)
+
 ## Install all cmake files
 install(DIRECTORY cmake/Modules
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/cmake)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ To use this with your ROS package:
    endif()
    ```
 
+   If you want to use Clang coverage tools:
+
+   ```
+     APPEND_COVERAGE_COMPILER_FLAGS(COMPILER clang)
+   ```
+
+
 * Now you can build and run the tests (you need a debug build to get reasonable coverage numbers):
 
   - if using CATKIN_MAKE:

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>code_coverage</name>
-  <version>0.4.4</version>
+  <version>0.4.5</version>
   <description>CMake configuration to run coverage</description>
   <author email="mike@vanadiumlabs.com">Michael Ferguson</author>
   <maintainer email="mike@vanadiumlabs.com">Michael Ferguson</maintainer>

--- a/scripts/llvm-gcov.sh
+++ b/scripts/llvm-gcov.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec llvm-cov gcov "$@"


### PR DESCRIPTION
With regard to issue https://github.com/mikeferguson/code_coverage/issues/30.

To use Clang coverage tools (llvm-cov), user will need to specify:

```
APPEND_COVERAGE_COMPILER_FLAGS(COMPILER clang)
```

Existing workflows remain the same as they were, no arguments to function:
```
APPEND_COVERAGE_COMPILER_FLAGS()
```
