### PR TITLE
Store python coverage report with other build artifacts

### DIFF
--- a/cmake/Modules/CodeCoverage.cmake
+++ b/cmake/Modules/CodeCoverage.cmake
@@ -139,10 +139,7 @@ function(ADD_CODE_COVERAGE)
     endif() # NOT GENHTML_PATH
 
     # Determine directory to store python coverage files
-    set(COVERAGE_DIR $ENV{HOME}/.ros)
-    if(DEFINED ENV{ROS_HOME})
-        set(COVERAGE_DIR $ENV{ROS_HOME})
-    endif()
+    set(COVERAGE_DIR ${PROJECT_BINARY_DIR})
 
     # Cleanup C++ counters
     add_custom_target(${Coverage_NAME}_cleanup_cpp


### PR DESCRIPTION
It's convenient to have the Python coverage report and related files within the binary directory of each package.  With the proposed change, calling `catkin_make -DENABLE_COVERAGE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug PACKAGE_NAME_coverage_report` puts the Python coverage report and related files generated in the workspace's `build/PACKAGE_NAME` directory.